### PR TITLE
feat: improve scroll responsiveness and reduce blank screen during scrolling

### DIFF
--- a/svelte/src/App.svelte
+++ b/svelte/src/App.svelte
@@ -76,12 +76,13 @@
         }
       } else {
         const percStart = el.scrollTop / el.scrollHeight
-        const offsetStart = Math.floor(percStart * $logStore.count)
+        const rawOffset = Math.floor(percStart * $logStore.count)
+        const offsetStart = Math.max(0, rawOffset - Math.floor($logStore.maxMessages / 2))
         logStore.changeToStatic(offsetStart)
       }
     },
-    100,
-    { leading: false, trailing: true },
+    50,
+    { leading: false, trailing: true, maxWait: 500 },
   )
 
   const onResize = debounce(
@@ -163,7 +164,11 @@
     {#if $logStore.window.length == 0}
       <div class="message message--info">No messages found</div>
     {:else}
-      <table bind:this={tableEl} class="windowLogs-table" style={lockedWidths ? 'table-layout: fixed' : ''}>
+      <table
+        bind:this={tableEl}
+        class="windowLogs-table"
+        style={lockedWidths ? 'table-layout: fixed' : ''}
+      >
         <thead>
           <tr style="height: {ROW_HEIGHT}px">
             <th style={lockedWidths ? `width: ${lockedWidths[0]}px` : ''} />


### PR DESCRIPTION
Closes #6

## Summary

- Reduce `onScroll` debounce from 100ms → 50ms for snappier response after scroll stops
- Add look-ahead buffer: request half a window of rows above the visible area so scrolling up has data pre-loaded before hitting the empty spacer
- Add `maxWait: 500` to the debounce so a server request fires every 500ms during continuous fast scrolling, preventing a prolonged blank screen

## Test plan

- [x] Pipe a large log file and scroll up — rows above the current view should load without a noticeable blank gap
- [x] Scroll continuously and quickly — log rows should refresh mid-scroll (~every 500ms), not only after stopping
- [x] Scroll back to the bottom — tail mode should re-engage seamlessly
- [x] Apply a filter and scroll — buffer and maxWait should both work correctly with filtered results